### PR TITLE
Type-safe constructor arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,13 @@ npm install sums-up
 ```typescript
 import SumType from 'sums-up';
 
-interface MatchPattern<T, A> {
-  Nothing(): T;
-  Just(a: A): T;
+class Maybe<T> extends SumType<{ Just: [T]; Nothing: [] }> {}
+
+function Just<T>(value: T): Maybe<T> {
+  return new Maybe("Just", value);
 }
 
-class Maybe<T, A> extends SumType<MatchPattern<T, A>> { }
-
-function Just<T, A>(a: A): Maybe<T, A> {
-  return new Maybe("Just", a);
-}
-
-function Nothing<T, A>(): Maybe<T, A> {
+function Nothing<T>(): Maybe<T> {
   return new Maybe("Nothing");
 }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "prepublish": "npm test"
   },
   "devDependencies": {
+    "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.5",
+    "@types/sinon": "^7.0.0",
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
     "sinon": "^6.1.5",

--- a/src/sumtype.ts
+++ b/src/sumtype.ts
@@ -1,6 +1,6 @@
-import { Setoid, Show } from './utils';
+import { Setoid, Show, Unshift } from './utils';
 
-function arrayEquals(a, b) {
+function arrayEquals(a: unknown[] | undefined, b: unknown[] | undefined) {
   if (a === b) return true;
   if (a == null || b == null) return false;
   if (a.length != b.length) return false;
@@ -11,20 +11,25 @@ function arrayEquals(a, b) {
   return true;
 }
 
-abstract class SumType<P> implements Setoid, Show {
-  private kind: string;
-  private data: any[];
+export type SumMembers = { [key: string]: unknown[] };
+export type KindAndData<T extends SumMembers> = { [K in keyof T]: Unshift<T[K], K> }[keyof T];
+export type CasePattern<T extends SumMembers, R> = { [K in keyof T]: (...args: T[K]) => R };
 
-  constructor(kind: string, ...data: any[]) {
+abstract class SumType<M extends SumMembers> implements Setoid, Show {
+  private kind: keyof M;
+  private data: unknown[];
+
+  constructor(...args: KindAndData<M>) {
+    let [kind, ...data] = args;
     this.kind = kind;
     this.data = data;
   }
 
-  public caseOf(pattern: P) {
-    return pattern[this.kind](...this.data);
+  public caseOf<T>(pattern: CasePattern<M, T>): T {
+    return (pattern[this.kind] as any)(...this.data);
   }
 
-  public equals(that: SumType<P>): boolean {
+  public equals(that: SumType<M>): boolean {
     return this.kind === that.kind && arrayEquals(this.data, that.data);
   }
 
@@ -33,7 +38,7 @@ abstract class SumType<P> implements Setoid, Show {
       return `${this.kind} ${JSON.stringify(this.data)}`;
     }
 
-    return this.kind;
+    return `${this.kind}`;
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,4 +6,6 @@ interface Show {
   toString(): string;
 }
 
-export { Setoid, Show };
+type Unshift<T extends any[], V, U = (a: V, ...b: T) => void> = U extends (...x: infer R) => void ? R : never;
+
+export { Setoid, Show, Unshift };

--- a/test/sumtype_test.ts
+++ b/test/sumtype_test.ts
@@ -1,19 +1,15 @@
 import { expect } from 'chai';
 import SumType from '../src/sumtype';
-import sinon from 'sinon';
+import sinon, { SinonSpy } from 'sinon';
 
 // Mock implementation
-interface MatchPattern<T, A> {
-  Nothing(): T;
-  Just(a: A): T;
-}
-class Maybe<T, A> extends SumType<MatchPattern<T, A>> {}
+class Maybe<T> extends SumType<{ Just: [T]; Nothing: [] }> {}
 
-function Just<T, A>(a: A): Maybe<T, A> {
-  return new Maybe('Just', a);
+function Just<T>(value: T): Maybe<T> {
+  return new Maybe('Just', value);
 }
 
-function Nothing<T, A>(): Maybe<T, A> {
+function Nothing<T>(): Maybe<T> {
   return new Maybe('Nothing');
 }
 
@@ -37,8 +33,8 @@ describe('SumType', () => {
   });
 
   describe('caseOf', () => {
-    let nothingSpy;
-    let justSpy;
+    let nothingSpy: SinonSpy;
+    let justSpy: SinonSpy;
     beforeEach(() => {
       nothingSpy = sinon.spy();
       justSpy = sinon.spy();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "declaration": true,
     "outDir": "dist",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strict": true
   },
   "exclude": [
     "node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,9 +18,19 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.0.0.tgz#9163742ac35c12d3602dece74317643b35db6a80"
 
+"@types/chai@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.7.tgz#1b8e33b61a8c09cbe1f85133071baa0dbf9fa71a"
+  integrity sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==
+
 "@types/mocha@^5.2.5":
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.5.tgz#8a4accfc403c124a0bafe8a9fc61a05ec1032073"
+
+"@types/sinon@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.0.0.tgz#84e707e157ec17d3e4c2a137f41fc3f416c0551e"
+  integrity sha512-kcYoPw0uKioFVC/oOqafk2yizSceIQXCYnkYts9vJIwQklFRsMubTObTDrjQamUyBRd47332s85074cd/hCwxg==
 
 arrify@^1.0.0:
   version "1.0.1"
@@ -287,8 +297,9 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 typescript@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
This change ensures that the arguments passed to `new MySumTypeSubclass` match the signature for the given member, e.g. it makes `new Maybe('Nothing', 'something')` and `new Maybe('Just')` illegal.

It also disentangles the case pattern return type from the signature of the sum type itself, which makes it a bit more ergonomic to define that signature inline for simple types, like `class Maybe<T> extends SumType<{ Just: [T]; Nothing: [] }>`.

Finally, it dials up the local strictness in `tsconfig.json` to help ensure all the pieces fit together properly.