### PR TITLE
Run build before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
-    "prepublish": "npm test"
+    "prepublish": "npm test && npm run build"
   },
   "devDependencies": {
     "@types/jest": "^23.3.13",


### PR DESCRIPTION
Previously was packaging without dist unless build was manually run before