### PR TITLE
Add support for wildcards in `caseOf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,27 @@ const result = x.caseOf({
 });
 ```
 
+### Wildcard Matching
+
+If the kind of a sum type instance isn't present in the pattern given to `caseOf`, a default key called `_` will be used instead.
+
+```ts
+import SumType from 'sums-up';
+
+class RequestState<T = never> extends SumType<{
+  NotStarted: [];
+  Connecting: [];
+  Downloading: [number];
+  Completed: [T];
+  Failed: [string];
+}> {}
+
+const state = new RequestState('Failed', 'Connection reset.');
+const progressPercentage = state.caseOf({
+  Downloading: pct => pct,
+  Completed: () => 100,
+  _: () => 0
+});
+```
+
 Contributors: @hojberg @dfreeman

--- a/__tests__/sumtype.test.ts
+++ b/__tests__/sumtype.test.ts
@@ -35,8 +35,8 @@ describe('SumType', () => {
     let nothingSpy: SinonSpy;
     let justSpy: SinonSpy;
     beforeEach(() => {
-      nothingSpy = sinon.spy();
-      justSpy = sinon.spy();
+      nothingSpy = sinon.spy(() => 'nothing');
+      justSpy = sinon.spy(() => 'just');
     });
 
     describe('Just', () => {
@@ -64,6 +64,33 @@ describe('SumType', () => {
       test('calls the Just function on the pattern', () => {
         expect(nothingSpy.called).toEqual(true);
         expect(justSpy.called).toEqual(false);
+      });
+    });
+
+    describe('_', () => {
+      let wildcardSpy: SinonSpy;
+      beforeEach(() => {
+        wildcardSpy = sinon.spy(() => 'wildcard');
+      });
+
+      test('calls the wildcard when no other kinds are given', () => {
+        let value = Just('hello').caseOf({ _: wildcardSpy });
+        expect(value).toEqual('wildcard');
+        expect(wildcardSpy.calledWithExactly()).toEqual(true);
+      });
+
+      test('calls the wildcard when no matching kind is given', () => {
+        let value = Just('hello').caseOf({ Nothing: nothingSpy, _: wildcardSpy });
+        expect(value).toEqual('wildcard');
+        expect(wildcardSpy.calledWithExactly()).toEqual(true);
+        expect(nothingSpy.called).toEqual(false);
+      });
+
+      test('skips the wildcard when a matching kind is given', () => {
+        let value = Just('hello').caseOf({ _: wildcardSpy, Just: justSpy });
+        expect(value).toEqual('just');
+        expect(wildcardSpy.called).toEqual(false);
+        expect(justSpy.calledWithExactly('hello')).toEqual(true);
       });
     });
   });


### PR DESCRIPTION
This PR adds the notion of a wildcard matcher to `caseOf`. This simplifies cases where you want to extract information from e.g. one particular member, otherwise using default data for any other type:

```ts
class MySum extends SumType<{
  A: [number];
  B: [string];
  C: [];
  D: [number, number];
}> {}

declare const value: MySum;

// Before
let defaultHandler = () => 'untitled';
let title = value.caseOf({
  A: defaultHandler,
  B: str => str,
  C: defaultHandler,
  D: defaultHandler,
});

// After
let title = value.caseOf({
  B: str => str,
  _: () => 'untitled',
});
```

If the wildcard arm matches, it never receives any data, regardless of what's stored for the actual kind in question. Patterns given to `caseOf` that don't include a `_` member are still required by the type system to be exhaustive.