### PR TITLE
Throw an error when a matching pattern is not found

### DIFF
--- a/__tests__/sumtype.test.ts
+++ b/__tests__/sumtype.test.ts
@@ -93,5 +93,21 @@ describe('SumType', () => {
         expect(justSpy.calledWithExactly('hello')).toEqual(true);
       });
     });
+
+    describe('missing pattern', () => {
+      test('throws the expected error when passed no patterns', () => {
+        const value = Just('hello');
+        expect(() => {
+          value.caseOf({} as any)
+        }).toThrowError('caseOf pattern is missing a function for Just');
+      });
+
+      test('throws the expected error when missing specific pattern', () => {
+        const value = Just('hello');
+        expect(() => {
+          value.caseOf({ Nothing: () => {} } as any)
+        }).toThrowError('caseOf pattern is missing a function for Just');
+      });
+    });
   });
 });

--- a/src/sumtype.ts
+++ b/src/sumtype.ts
@@ -31,8 +31,10 @@ abstract class SumType<M extends Variants> implements Setoid, Show {
   public caseOf<T>(pattern: CasePattern<M, T>): T {
     if (this.kind in pattern) {
       return (pattern[this.kind] as any)(...this.data);
-    } else {
+    } else if (pattern._) {
       return pattern._();
+    } else {
+      throw `caseOf pattern is missing a function for ${this.kind}`;
     }
   }
 


### PR DESCRIPTION
Previously as a result of the new wildcard matching the error returned when not all cases are defined was:
`Uncaught TypeError: pattern._ is not a function`

Which isn't immediately obvious that you're missing a case as it's blowing up on attempting to call the wildcard func

Throw a specific error instead