### PR TITLE
Use new private modifier to completely hide data

### DIFF
--- a/__tests__/sumtype.test.ts
+++ b/__tests__/sumtype.test.ts
@@ -1,112 +1,115 @@
-import SumType from '../src/sumtype';
-import sinon, { SinonSpy } from 'sinon';
+import SumType from "../src/sumtype";
+import sinon, { SinonSpy } from "sinon";
 
 // Mock implementation
 class Maybe<T> extends SumType<{ Just: [T]; Nothing: [] }> {}
 
 function Just<T>(value: T): Maybe<T> {
-  return new Maybe('Just', value);
+  return new Maybe("Just", value);
 }
 
 function Nothing<T>(): Maybe<T> {
-  return new Maybe('Nothing');
+  return new Maybe("Nothing");
 }
 
-describe('SumType', () => {
-  describe('equals', () => {
-    test('is equal when both the kind and the wrapped value match', () => {
+describe("SumType", () => {
+  describe("equals", () => {
+    test("is equal when both the kind and the wrapped value match", () => {
       expect(Just(1).equals(Just(1))).toEqual(true);
       expect(Just(1).equals(Just(2))).toEqual(false);
     });
 
-    test('is not equal when the kind differ', () => {
+    test("is not equal when the kind differ", () => {
       expect(Just(1).equals(Nothing())).toEqual(false);
     });
   });
 
-  describe('toString', () => {
-    test('outputs the kind and the data', () => {
-      expect(Just(1).toString()).toEqual('Just [1]');
-      expect(Nothing().toString()).toEqual('Nothing');
+  describe("toString", () => {
+    test("outputs the kind and the data", () => {
+      expect(Just(1).toString()).toEqual("Just [1]");
+      expect(Nothing().toString()).toEqual("Nothing");
     });
   });
 
-  describe('caseOf', () => {
+  describe("caseOf", () => {
     let nothingSpy: SinonSpy<[], string>;
     let justSpy: SinonSpy<[unknown], string>;
     beforeEach(() => {
-      nothingSpy = sinon.spy(() => 'nothing');
-      justSpy = sinon.spy((_) => 'just');
+      nothingSpy = sinon.spy(() => "nothing");
+      justSpy = sinon.spy(_ => "just");
     });
 
-    describe('Just', () => {
+    describe("Just", () => {
       beforeEach(() => {
-        Just('foo').caseOf({
+        Just("foo").caseOf({
           Nothing: nothingSpy,
-          Just: justSpy,
+          Just: justSpy
         });
       });
 
-      test('calls the Just function on the pattern', () => {
+      test("calls the Just function on the pattern", () => {
         expect(nothingSpy.called).toEqual(false);
-        expect(justSpy.calledWith('foo')).toEqual(true);
+        expect(justSpy.calledWith("foo")).toEqual(true);
       });
     });
 
-    describe('Nothing', () => {
+    describe("Nothing", () => {
       beforeEach(() => {
         Nothing().caseOf({
           Nothing: nothingSpy,
-          Just: justSpy,
+          Just: justSpy
         });
       });
 
-      test('calls the Just function on the pattern', () => {
+      test("calls the Just function on the pattern", () => {
         expect(nothingSpy.called).toEqual(true);
         expect(justSpy.called).toEqual(false);
       });
     });
 
-    describe('_', () => {
+    describe("_", () => {
       let wildcardSpy: SinonSpy<[], string>;
       beforeEach(() => {
-        wildcardSpy = sinon.spy(() => 'wildcard');
+        wildcardSpy = sinon.spy(() => "wildcard");
       });
 
-      test('calls the wildcard when no other kinds are given', () => {
-        let value = Just('hello').caseOf({ _: wildcardSpy });
-        expect(value).toEqual('wildcard');
+      test("calls the wildcard when no other kinds are given", () => {
+        let value = Just("hello").caseOf({ _: wildcardSpy });
+        expect(value).toEqual("wildcard");
         expect(wildcardSpy.calledWithExactly()).toEqual(true);
       });
 
-      test('calls the wildcard when no matching kind is given', () => {
-        let value = Just('hello').caseOf({ Nothing: nothingSpy, _: wildcardSpy });
-        expect(value).toEqual('wildcard');
+      test("calls the wildcard when no matching kind is given", () => {
+        let value = Just("hello").caseOf({
+          Nothing: nothingSpy,
+          _: wildcardSpy
+        });
+        expect(value).toEqual("wildcard");
         expect(wildcardSpy.calledWithExactly()).toEqual(true);
         expect(nothingSpy.called).toEqual(false);
       });
 
-      test('skips the wildcard when a matching kind is given', () => {
-        let value = Just('hello').caseOf({ _: wildcardSpy, Just: justSpy });
-        expect(value).toEqual('just');
+      test("skips the wildcard when a matching kind is given", () => {
+        let value = Just("hello").caseOf({ _: wildcardSpy, Just: justSpy });
+        expect(value).toEqual("just");
         expect(wildcardSpy.called).toEqual(false);
-        expect(justSpy.calledWithExactly('hello')).toEqual(true);
+        expect(justSpy.calledWithExactly("hello")).toEqual(true);
       });
     });
 
-    describe('missing pattern', () => {
-      test('throws the expected error when passed no patterns', () => {
-        const value = Just('hello');
+    describe("missing pattern", () => {
+      test("throws the expected error when passed no patterns", () => {
+        const value = Just("hello");
         expect(() => {
-          value.caseOf({} as any)
-        }).toThrowError('caseOf pattern is missing a function for Just');
+          value.caseOf({} as any);
+        }).toThrowError("caseOf pattern is missing a function for Just");
       });
 
-      test('throws the expected error when missing specific pattern', () => {
-        const value = Just('hello');
+      test("throws the expected error when missing specific pattern", () => {
+        const value = Just("hello");
         expect(() => {
-          value.caseOf({ Nothing: () => {} } as any)
-        }).toThrowError('caseOf pattern is missing a function for Just');
+          value.caseOf({ Nothing: () => {} } as any);
+        }).toThrowError("caseOf pattern is missing a function for Just");
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "sinon": "^8.0.2",
     "ts-jest": "^24.2.0",
     "ts-node": "^8.5.4",
-    "typescript": "^3.7.4"
+    "typescript": "^3.8.3"
   }
 }

--- a/src/sumtype.ts
+++ b/src/sumtype.ts
@@ -19,35 +19,35 @@ export type CasePattern<T extends Variants, R> =
   | Partial<ExhaustiveCasePattern<T, R>> & { _: () => R };
 
 abstract class SumType<M extends Variants> implements Setoid, Show {
-  private kind: keyof M;
-  private data: unknown[];
+  #kind: keyof M;
+  #data: unknown[];
 
   constructor(...args: KindAndData<M>) {
     let [kind, ...data] = args;
-    this.kind = kind;
-    this.data = data;
+    this.#kind = kind;
+    this.#data = data;
   }
 
   public caseOf<T>(pattern: CasePattern<M, T>): T {
-    if (this.kind in pattern) {
-      return (pattern[this.kind] as any)(...this.data);
+    if (this.#kind in pattern) {
+      return (pattern[this.#kind] as any)(...this.#data);
     } else if (pattern._) {
       return pattern._();
     } else {
-      throw new Error(`caseOf pattern is missing a function for ${this.kind}`);
+      throw new Error(`caseOf pattern is missing a function for ${this.#kind}`);
     }
   }
 
   public equals(that: SumType<M>): boolean {
-    return this.kind === that.kind && arrayEquals(this.data, that.data);
+    return this.#kind === that.#kind && arrayEquals(this.#data, that.#data);
   }
 
   public toString(): string {
-    if (this.data.length) {
-      return `${this.kind} ${JSON.stringify(this.data)}`;
+    if (this.#data.length) {
+      return `${this.#kind} ${JSON.stringify(this.#data)}`;
     }
 
-    return `${this.kind}`;
+    return `${this.#kind}`;
   }
 }
 


### PR DESCRIPTION
With the new private modifier added to TypeScript (via ES) we can completely hide `data` and `kind` on a sum type. I've seen people grab into this and this should help steer people in the right direction.

Side note: I wonder if this warrants a major version bump - No one should be using these private fields, but it has been possible to do so and like I mentioned, I've seen people do it.