### PR TITLE
Export Variants type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import SumType from './sumtype';
-import { Show, Setoid } from './utils';
+import SumType, { Variants } from "./sumtype";
+import { Show, Setoid } from "./utils";
 
 export default SumType;
-export { SumType, Show, Setoid };
+export { SumType, Show, Setoid, Variants };


### PR DESCRIPTION
The `Variants` type is useful for other libraries to confirm to when we want to discuss sum types in general that are unspecific.